### PR TITLE
Add sudo to base images

### DIFF
--- a/scripts/docker/buildpack-deps/Dockerfile.emscripten
+++ b/scripts/docker/buildpack-deps/Dockerfile.emscripten
@@ -39,7 +39,7 @@ ADD emscripten.jam /usr/src
 RUN set -ex && \
 	\
 	apt-get update && \
-	apt-get install lz4 --no-install-recommends && \
+	apt-get install lz4 sudo --no-install-recommends && \
 	\
 	cd /usr/src && \
 	git clone https://github.com/Z3Prover/z3.git -b z3-4.12.1 --depth 1 && \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
@@ -28,7 +28,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update; \
 	apt-get -qqy install --no-install-recommends \
-		build-essential \
+		build-essential sudo \
 		software-properties-common \
 		ninja-build git wget \
 		libbz2-dev zlib1g-dev git curl uuid-dev \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
@@ -32,7 +32,7 @@ RUN set -ex; \
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
 	apt-get update; \
 	apt-get install -qqy --no-install-recommends \
-		build-essential \
+		build-essential sudo \
 		software-properties-common \
 		cmake ninja-build \
 		libboost-filesystem-dev libboost-test-dev libboost-system-dev \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204
@@ -32,7 +32,7 @@ RUN set -ex; \
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
 	apt-get update; \
 	apt-get install -qqy --no-install-recommends \
-		build-essential \
+		build-essential sudo \
 		software-properties-common \
 		cmake ninja-build \
 		libboost-filesystem-dev libboost-test-dev libboost-system-dev \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204.clang
@@ -32,7 +32,7 @@ RUN set -ex; \
 	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
 	apt-get update; \
 	apt-get install -qqy --no-install-recommends \
-		build-essential \
+		build-essential sudo \
 		software-properties-common \
 		cmake ninja-build \
 		libboost-filesystem-dev libboost-test-dev libboost-system-dev \


### PR DESCRIPTION
Some images lack the `sudo` command. This PR adds it to all builder images so they are compatible with the `cimg` images provided by CircleCI: https://circleci.com/docs/circleci-images/#pre-installed-tools 


This is just a test to run gh actions ;)